### PR TITLE
Update GitHub notifications

### DIFF
--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -9,7 +9,7 @@ jobs:
   security-check:
     name: Security Check
     runs-on: ubuntu-latest
-    container: openjdk:17-jdk-slim
+    container: eclipse-temurin:17
     steps:
       - uses: actions/checkout@v3
       - name: Grant execute permission for gradlew
@@ -36,13 +36,18 @@ jobs:
         with:
           name: dependency-check-report-baselining
           path: ${{ github.workspace }}/reports
-      - name: Send Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*Baselining Dependency-Check Report*: ${{ steps.depcheck.outcome }}\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Since GitHub cannot send emails directly, we use an external API
+      - name: Send Notification via Resend
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
+              "to": ["info.inspectit@novatec-gmbh.de"],
+              "subject": "Baselining Dependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "html": "<p>The Dependency-Check for ${{ github.repository }} completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
+            }'
       # if DependencyCheck failed, the job should also fail, but only after the results were uploaded
       - name: Validate DependencyCheck outcome
         if: ${{ steps.depcheck.outcome == 'failure' }}


### PR DESCRIPTION
Replace Slack notifications with Email. Since GitHub cannot send emails directy, we use [Resend](https://resend.com/).